### PR TITLE
Github action: run tests and checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: npm install
+      - name: Check types
+        run: npx tsc --project tsconfig.json
+
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: npm ci
+      - run: npm run test
+
+  eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Dependencies
+        run: npm ci
+      - run: npm run lint

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "lint": "eslint --ignore-path .gitignore .",
     "predeploy": "npm run build",
     "deploy": "gh-pages -d build"
   },

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -19,15 +19,15 @@ describe("'New card' button", () => {
   test("clears any stamped cells", () => {
     render(<App/>)
     const cells = screen.queryAllByRole("cell")
-    const firstCell = cells[0]
 
-    fireEvent.click(firstCell)
+    fireEvent.click(cells[0])
 
-    expect(firstCell).toHaveClass("stamped")
+    expect(cells[0]).toHaveClass("stamped")
 
     fireEvent.click(screen.getByText("New card"))
 
-    expect(firstCell).not.toHaveClass("stamped")
+    const updatedCells = screen.queryAllByRole("cell")
+    expect(updatedCells[0]).not.toHaveClass("stamped")
   });
 });
 


### PR DESCRIPTION
This adds a github action which will run the server tests on all PRs and
any time there's a push to main.

Use `npm ci` instead of `npm install` for a faster build (?) and to ensure
that package-lock.json isn't changed when installing packages.

I'm not super sure if the typechecks are necessary (will we get compilation
errors when running the app if there are type errors?)