### PR TITLE
Fix: disappearing footer class

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,7 +5,7 @@ import classNames from "classnames";
 
 const Footer: React.FC<{ className?: string }> = ({ className }) => {
   return (
-    <footer className={classNames("Footer", { className: className })}>
+    <footer className={classNames("Footer", className)}>
       <ul>
         <li>
           <Link to="/word_list">Full word list</Link>


### PR DESCRIPTION
After navigating back and forth this became a class called "className" - I still don't 100% understand how this classNames helper works.