### PR TITLE
Tweak the share button

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -61,14 +61,15 @@ const Card: React.FC<{ wordList: string[] }> = ({ wordList }) => {
 
   const copyBoardToClipboard: ButtonClickHandler = () => {
     const message = emojiGrid(cellDataList);
+
+    window.navigator.clipboard.writeText(message);
+
     if (window.navigator.share) {
       window.navigator.share({
-        title: "My Team Lindy Bingo card",
+        title: "Team Lindy Bingo",
         text: message,
         url: "https://bit.ly/lindybingocard",
       });
-    } else {
-      window.navigator.clipboard.writeText(message);
     }
   };
 


### PR DESCRIPTION
1. Always copy to clipboard, even if share functionality is available

This is because for some share types (eg. Facebook) the "text" part is
discarded, and I want people to be able to share their cards, not just
the links.

2. Update title

When selecting "copy" from the share menu, the "text" is presented as a
link, with the "url" as the URL, so the text should reflect what the
link is.